### PR TITLE
add a pre-commit-hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    -   id: trailing-whitespace


### PR DESCRIPTION
Add a pre-commit-hook config file

link: https://pre-commit.com/
https://github.com/pre-commit/pre-commit-hooks
usage: 
1) pip install pre-commit to install the frame
2) select the hook you want by adding id to config file
3) use pre-commit install to generate the real hook in your local .git/hooks